### PR TITLE
feat: add CLI for reading and updating markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install comment-mark
 Update marked sections in a Markdown file directly from the command line. Each `--<marker>=<value>` flag fills the matching marker:
 
 ```sh
-comment-mark README.md --last-updated="$(date -Iseconds)"
+comment-mark README.md --lastUpdated="$(date -Iseconds)"
 ```
 
 ```md
@@ -26,7 +26,7 @@ Multiple markers can be set in one invocation:
 ```sh
 comment-mark README.md \
     --contributors="$(git shortlog -se HEAD -- .)" \
-    --last-updated="$(date -Iseconds)"
+    --lastUpdated="$(date -Iseconds)"
 ```
 
 Running without marker flags lists every detected marker and its content as JSON, which is handy for scripting:
@@ -39,7 +39,7 @@ The setter reports each key's outcome (`Updated`, `Unchanged`, or `Missing`) and
 
 ```text
 Updated: contributors
-Unchanged: last-updated
+Unchanged: lastUpdated
 Missing: benchmarks
 
 Saved README.md. Updated 1 key; 1 unchanged; 1 missing.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,29 @@
 npm install comment-mark
 ```
 
+## CLI
+
+Update marked sections in a Markdown file directly from the command line. Each `--<marker>=<value>` flag fills the matching marker:
+
+```sh
+comment-mark README.md --last-updated="$(date -Iseconds)"
+```
+
+```md
+## Last updated
+<!-- lastUpdated:start -->2026-09-07T00:00:00+09:00<!-- lastUpdated:end -->
+```
+
+Multiple markers can be set in one invocation:
+
+```sh
+comment-mark README.md \
+    --contributors="$(git shortlog -se HEAD -- .)" \
+    --last-updated="$(date -Iseconds)"
+```
+
+Running without marker flags prints the file's content to stdout instead of writing.
+
 ## Quick start
 
 ### 1. Add placeholders to your Markdown
@@ -86,6 +109,19 @@ fs.writeFileSync('README.md', markdown)
 ```
 
 ## API
+
+### CLI
+
+```sh
+comment-mark <file> [--<marker>=<value>...]
+```
+
+* `file` `<string>`: Path to the Markdown or HTML file to update in place.
+* `--<marker>=<value>`: Value for the marker named `<marker>`. Repeatable for multiple markers. Multiline values are supported.
+
+When at least one marker flag is given, the file is rewritten in place with the marked sections updated. Without marker flags, the processed content is printed to stdout and the file is left untouched.
+
+Markers that don't exist in the file are ignored.
 
 ### `commentMark(contentStr, data)`
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ comment-mark README.md \
     --last-updated="$(date -Iseconds)"
 ```
 
-Running without marker flags prints the file's content to stdout instead of writing.
+Running without marker flags is an error; the file is left untouched.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,23 @@ comment-mark README.md \
     --last-updated="$(date -Iseconds)"
 ```
 
-Running without marker flags is an error; the file is left untouched.
+Running without marker flags lists every detected marker and its content as JSON, which is handy for scripting:
+
+```sh
+comment-mark README.md | jq -r '.contributors'
+```
+
+The setter reports each key's outcome (`Updated`, `Unchanged`, or `Missing`) and always uses `--<marker>=<value>` syntax. A marker that doesn't exist doesn't block the other updates, but the command exits non-zero so typos and stale scripts surface:
+
+```text
+Updated: contributors
+Unchanged: last-updated
+Missing: benchmarks
+
+Saved README.md. Updated 1 key; 1 unchanged; 1 missing.
+```
+
+When every requested value already matches, the file is left untouched and the command exits successfully.
 
 ## Quick start
 
@@ -116,12 +132,24 @@ fs.writeFileSync('README.md', markdown)
 comment-mark <file> [--<marker>=<value>...]
 ```
 
-* `file` `<string>`: Path to the Markdown or HTML file to update in place.
-* `--<marker>=<value>`: Value for the marker named `<marker>`. Repeatable for multiple markers. Multiline values are supported.
+* `file` `<string>`: Path to the Markdown or HTML file.
+* `--<marker>=<value>`: Value for the marker named `<marker>`. Repeat for multiple markers. Multiline values are supported.
 
-When at least one marker flag is given, the file is rewritten in place with the marked sections updated. Without marker flags, the processed content is printed to stdout and the file is left untouched.
+**Get mode.** Without marker flags, prints every detected marker and its exact content as JSON to stdout and exits `0`. Exits non-zero if the file can't be read or contains an unterminated marker.
 
-Markers that don't exist in the file are ignored.
+**Set mode.** With one or more marker flags, validates the whole document first (an unterminated marker aborts without writing), then updates the marked sections in place. Status for each key is printed to stderr:
+
+* `Updated`: the marker existed and its content changed.
+* `Unchanged`: the marker already held the requested value.
+* `Missing`: no matching marker exists in the file.
+
+Valid updates are still saved when other requested markers are missing, but the command exits `1` in that case so automation can detect incomplete runs. When every requested value already matches, the file is not rewritten and the command exits `0`.
+
+Additional rules:
+
+* Each marker can only be set once per invocation; repeated flags are rejected.
+* Marker names are exact; `--last-updated` does not match a `lastUpdated` marker.
+* Bare `--help`, `-h`, and `--version` are reserved. Set a marker named `help` or `version` with `--help=<value>` or `--version=<value>`.
 
 ### `commentMark(contentStr, data)`
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 	"files": [
 		"dist"
 	],
+	"bin": "./dist/cli.mjs",
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",
 	"types": "./dist/index.d.cts",
@@ -52,6 +53,9 @@
 	},
 	"engines": {
 		"node": ">=20"
+	},
+	"dependencies": {
+		"cleye": "^2.6.0"
 	},
 	"devDependencies": {
 		"@types/node": "^24.13.3",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,10 @@
 	"devDependencies": {
 		"@types/node": "^24.13.3",
 		"clean-pkg-json": "^2.0.0",
+		"fs-fixture": "^2.16.0",
 		"lintroll": "^1.31.1",
 		"manten": "^2.0.2",
+		"nano-spawn": "^2.1.0",
 		"pkgroll": "^2.28.1",
 		"skills-npm": "^1.2.1",
 		"tsx": "^4.23.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,12 +119,18 @@ importers:
       clean-pkg-json:
         specifier: ^2.0.0
         version: 2.0.0
+      fs-fixture:
+        specifier: ^2.16.0
+        version: 2.16.0
       lintroll:
         specifier: ^1.31.1
         version: 1.31.1(@typescript-eslint/utils@8.69.0(eslint@9.39.5(jiti@2.6.1)(supports-color@7.2.0))(supports-color@7.2.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.9(supports-color@7.2.0))(eslint-plugin-import@2.31.0)(jiti@2.6.1)(supports-color@7.2.0)(typescript@6.0.3)
       manten:
         specifier: ^2.0.2
         version: 2.0.2
+      nano-spawn:
+        specifier: ^2.1.0
+        version: 2.1.0
       pkgroll:
         specifier: ^2.28.1
         version: 2.28.1(@typescript/typescript6@6.0.2)(typescript@6.0.3)
@@ -1680,6 +1686,10 @@ packages:
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
+
+  fs-fixture@2.16.0:
+    resolution: {integrity: sha512-wLgUrK+xH81K9shOMrQATJKbZTCPDxtmlt8s9iyE7vy0/H5KSXgKm9UPFzz7D08VCAYFvqw6JNnlFmJ/ukVWnQ==}
+    engines: {node: '>=18.0.0'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -4464,6 +4474,8 @@ snapshots:
       is-callable: 1.2.7
 
   format@0.2.2: {}
+
+  fs-fixture@2.16.0: {}
 
   fsevents@2.3.3:
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      cleye:
+        specifier: ^2.6.0
+        version: 2.6.0
     devDependencies:
       '@types/node':
         specifier: ^24.13.3

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,31 +1,71 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import { cli } from 'cleye';
 import { description, name, version } from '../package.json' with { type: 'json' };
-import { commentMark } from './index.js';
+import { commentMark, getCommentMarks } from './index.js';
 
 const exitWithError = (message: string): never => {
 	console.error(`Error: ${message}`);
 	process.exit(1);
 };
 
+// `help: false` disables cleye's built-in flag handling so `--help`/`--version`
+// don't intercept `--help=<value>`/`--version=<value>` meant as marker keys.
+// Bare `--help`/`-h`/`--version` are handled manually below.
+const helpOptions = {
+	description,
+	usage: `${name} <file> [--<marker>=<value>...]`,
+	examples: [
+		`${name} README.md --last-updated="$(date -Iseconds)"`,
+		`${name} README.md --contributors="$(git shortlog -se HEAD -- .)"`,
+	],
+};
+
 const argv = cli({
 	name,
-	version,
-	parameters: ['<file>'],
-	help: {
-		description,
-		usage: `${name} <file> [--<marker>=<value>...]`,
-		examples: [
-			`${name} README.md --last-updated="$(date -Iseconds)"`,
-			`${name} README.md --contributors="$(git shortlog -se HEAD -- .)"`,
-		],
-	},
+	parameters: ['[file]'],
+	help: false,
 });
+
+const { unknownFlags, showHelp } = argv;
+
+const isBareFlag = (flagName: string) => {
+	const values = unknownFlags[flagName];
+	return values?.length === 1 && values[0] === true;
+};
+
+// Handle control flags manually, matching cleye's convention that a bare flag
+// anywhere requests the action.
+if (isBareFlag('help') || isBareFlag('h')) {
+	showHelp(helpOptions);
+	process.exit(0);
+}
+
+if (isBareFlag('version')) {
+	console.log(version);
+	process.exit(0);
+}
+
+const filePath = argv._.file;
+
+// Inline exit (rather than the exitWithError helper) so TypeScript's control
+// flow analysis narrows `filePath` to a string below.
+if (!filePath) {
+	console.error('Error: Missing required parameter "<file>"');
+	process.exit(1);
+}
+
+if (argv._.length > 1) {
+	exitWithError(`Unexpected extra arguments: ${argv._.slice(1).join(', ')}`);
+}
 
 const data: Record<string, string> = {};
 
-for (const [marker, values] of Object.entries(argv.unknownFlags)) {
-	const value = values.at(-1);
+for (const [marker, values] of Object.entries(unknownFlags)) {
+	if (values.length > 1) {
+		exitWithError(`Flag "--${marker}" was specified ${values.length} times; each marker can only be set once`);
+	}
+
+	const value = values[0];
 	if (typeof value === 'string') {
 		data[marker] = value;
 	} else {
@@ -33,9 +73,85 @@ for (const [marker, values] of Object.entries(argv.unknownFlags)) {
 	}
 }
 
+// Get mode: no marker flags prints detected values as JSON.
 if (Object.keys(data).length === 0) {
-	exitWithError('No marker flags provided. Pass --<marker>=<value> flags to update sections (see --help)');
+	const content = await readFile(filePath, 'utf8');
+	process.stdout.write(`${JSON.stringify(getCommentMarks(content), null, '\t')}\n`);
+	process.exit(0);
 }
 
-const output = commentMark(await readFile(argv._.file, 'utf8'), data);
-await writeFile(argv._.file, output);
+// Setter mode: validate the whole document and classify every requested key
+// before writing, so a malformed marker never leaves partial edits behind.
+const original = await readFile(filePath, 'utf8');
+
+let output: string | Buffer;
+let detected: Record<string, string>;
+try {
+	output = commentMark(original, data);
+	detected = getCommentMarks(original);
+} catch (error) {
+	if (error instanceof Error) {
+		exitWithError(error.message);
+	}
+
+	throw error;
+}
+
+// The library silently skips keys with no matching marker; detect them so
+// typos surface instead of succeeding quietly.
+const updated: string[] = [];
+const unchanged: string[] = [];
+const missing: string[] = [];
+
+for (const [marker, value] of Object.entries(data)) {
+	if (!Object.hasOwn(detected, marker)) {
+		missing.push(marker);
+		continue;
+	}
+
+	// Compare against a solo application so each key is classified by its own
+	// effect, independent of the other keys' replacements.
+	const soloOutput = commentMark(original, { [marker]: value });
+	if (soloOutput === original) {
+		unchanged.push(marker);
+	} else {
+		updated.push(marker);
+	}
+}
+
+const report = () => {
+	if (updated.length > 0) {
+		console.error(`Updated: ${updated.join(', ')}`);
+	}
+	if (unchanged.length > 0) {
+		console.error(`Unchanged: ${unchanged.join(', ')}`);
+	}
+	if (missing.length > 0) {
+		console.error(`Missing: ${missing.join(', ')}`);
+	}
+};
+
+if (missing.length === Object.keys(data).length) {
+	report();
+	exitWithError(`No matching markers found for any of the ${missing.length} requested keys`);
+}
+
+if (updated.length === 0) {
+	console.error(`${filePath} is unchanged. All ${Object.keys(data).length} requested values already match.`);
+	process.exit(0);
+}
+
+await writeFile(filePath, output);
+
+report();
+
+const summary = [
+	unchanged.length > 0 && `${unchanged.length} unchanged`,
+	missing.length > 0 && `${missing.length} missing`,
+].filter(Boolean).join('; ');
+
+console.error(`Saved ${filePath}. Updated ${updated.length} key${updated.length === 1 ? '' : 's'}${summary ? `; ${summary}` : ''}.`);
+
+if (missing.length > 0) {
+	process.exitCode = 1;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,16 +1,26 @@
 import { readFile, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { cli } from 'cleye';
 import { commentMark } from './index.js';
 
+const require = createRequire(import.meta.url);
+
+const { name, description, version } = require('../package.json') as {
+	name: string;
+	description: string;
+	version: string;
+};
+
 const argv = cli({
-	name: 'comment-mark',
+	name,
+	version,
 	parameters: ['<file>'],
 	help: {
-		description: 'Update marked sections in a Markdown file with arbitrary values.',
-		usage: 'comment-mark <file> [--<marker>=<value>...]',
+		description,
+		usage: `${name} <file> [--<marker>=<value>...]`,
 		examples: [
-			'comment-mark README.md --last-updated="$(date -Iseconds)"',
-			'comment-mark README.md --contributors="$(git shortlog -se HEAD -- .)"',
+			`${name} README.md --last-updated="$(date -Iseconds)"`,
+			`${name} README.md --contributors="$(git shortlog -se HEAD -- .)"`,
 		],
 	},
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,15 +1,7 @@
 import { readFile, writeFile } from 'node:fs/promises';
-import { createRequire } from 'node:module';
 import { cli } from 'cleye';
+import { description, name, version } from '../package.json' with { type: 'json' };
 import { commentMark } from './index.js';
-
-const require = createRequire(import.meta.url);
-
-const { name, description, version } = require('../package.json') as {
-	name: string;
-	description: string;
-	version: string;
-};
 
 const argv = cli({
 	name,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,11 @@ import { cli } from 'cleye';
 import { description, name, version } from '../package.json' with { type: 'json' };
 import { commentMark } from './index.js';
 
+const exitWithError = (message: string): never => {
+	console.error(`Error: ${message}`);
+	process.exit(1);
+};
+
 const argv = cli({
 	name,
 	version,
@@ -21,19 +26,16 @@ const data: Record<string, string> = {};
 
 for (const [marker, values] of Object.entries(argv.unknownFlags)) {
 	const value = values.at(-1);
-	if (typeof value !== 'string') {
-		throw new TypeError(`No value provided for flag "--${marker}" (expected --${marker}=<value>)`);
+	if (typeof value === 'string') {
+		data[marker] = value;
+	} else {
+		exitWithError(`No value provided for flag "--${marker}" (expected --${marker}=<value>)`);
 	}
+}
 
-	data[marker] = value;
+if (Object.keys(data).length === 0) {
+	exitWithError('No marker flags provided. Pass --<marker>=<value> flags to update sections (see --help)');
 }
 
 const output = commentMark(await readFile(argv._.file, 'utf8'), data);
-
-// Only rewrite the file when at least one marker key was provided so accidental
-// flagless invocations don't touch the file.
-if (Object.keys(data).length > 0) {
-	await writeFile(argv._.file, output);
-} else {
-	process.stdout.write(output);
-}
+await writeFile(argv._.file, output);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,9 +8,6 @@ const exitWithError = (message: string): never => {
 	process.exit(1);
 };
 
-// `help: false` disables cleye's built-in flag handling so `--help`/`--version`
-// don't intercept `--help=<value>`/`--version=<value>` meant as marker keys.
-// Bare `--help`/`-h`/`--version` are handled manually below.
 const helpOptions = {
 	description,
 	usage: `${name} <file> [--<marker>=<value>...]`,
@@ -23,6 +20,10 @@ const helpOptions = {
 const argv = cli({
 	name,
 	parameters: ['[file]'],
+
+	// Markers accept arbitrary names, so a marker can be named `help`. cleye's
+	// default Boolean `help` flag (alias `-h`) would consume `--help=<value>`
+	// and print help instead, so it's disabled; bare flags are handled below.
 	help: false,
 });
 
@@ -33,8 +34,8 @@ const isBareFlag = (flagName: string) => {
 	return values?.length === 1 && values[0] === true;
 };
 
-// Handle control flags manually, matching cleye's convention that a bare flag
-// anywhere requests the action.
+// Handle control flags manually so only the bare form reserves the action
+// (cleye convention); `--help=<value>`/`--version=<value>` stay as markers.
 if (isBareFlag('help') || isBareFlag('h')) {
 	showHelp(helpOptions);
 	process.exit(0);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,10 @@ const helpOptions = {
 
 const argv = cli({
 	name,
+
+	// Keep `[file]` optional: a required `<file>` aborts inside cli() with
+	// "Missing required parameter" before the manual `--help`/`--version`
+	// handlers below can run. The requirement is enforced after those flags.
 	parameters: ['[file]'],
 
 	// Markers accept arbitrary names, so a marker can be named `help`. cleye's

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,37 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { cli } from 'cleye';
+import { commentMark } from './index.js';
+
+const argv = cli({
+	name: 'comment-mark',
+	parameters: ['<file>'],
+	help: {
+		description: 'Update marked sections in a Markdown file with arbitrary values.',
+		usage: 'comment-mark <file> [--<marker>=<value>...]',
+		examples: [
+			'comment-mark README.md --last-updated="$(date -Iseconds)"',
+			'comment-mark README.md --contributors="$(git shortlog -se HEAD -- .)"',
+		],
+	},
+});
+
+const data: Record<string, string> = {};
+
+for (const [marker, values] of Object.entries(argv.unknownFlags)) {
+	const value = values.at(-1);
+	if (typeof value !== 'string') {
+		throw new TypeError(`No value provided for flag "--${marker}" (expected --${marker}=<value>)`);
+	}
+
+	data[marker] = value;
+}
+
+const output = commentMark(await readFile(argv._.file, 'utf8'), data);
+
+// Only rewrite the file when at least one marker key was provided so accidental
+// flagless invocations don't touch the file.
+if (Object.keys(data).length > 0) {
+	await writeFile(argv._.file, output);
+} else {
+	process.stdout.write(output);
+}

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,5 +1,34 @@
+import {
+	mkdtemp, rm, writeFile, readFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { describe, test, expect } from 'manten';
 import { commentMark, getCommentMarks } from '#comment-mark';
+
+const execFileAsync = promisify(execFile);
+const cliPath = new URL('../dist/cli.mjs', import.meta.url).pathname;
+
+const runCli = (...args: string[]) => execFileAsync('node', [cliPath, ...args], {
+	encoding: 'utf8',
+});
+
+const createMarkdownFile = async (content: string) => {
+	const directory = await mkdtemp(path.join(tmpdir(), 'comment-mark-cli-'));
+	const filePath = path.join(directory, 'README.md');
+	await writeFile(filePath, content, 'utf8');
+	return {
+		filePath,
+		cleanup: async () => {
+			await rm(directory, {
+				recursive: true,
+				force: true,
+			});
+		},
+	};
+};
 
 describe('edge cases', () => {
 	test('no arguments', () => {
@@ -193,5 +222,81 @@ goodbye world
 		});
 
 		expect(getCommentMarks(output)).toEqual({ a: 'hello world' });
+	});
+});
+
+describe('CLI', () => {
+	test('updates a marked section in place', async () => {
+		const file = await createMarkdownFile(
+			'## Contributors\n<!-- contributors:start -->stale<!-- contributors:end -->\n',
+		);
+
+		try {
+			await runCli(file.filePath, '--contributors=Jane Doe');
+
+			expect(await readFile(file.filePath, 'utf8')).toBe(
+				'## Contributors\n<!-- contributors:start -->Jane Doe<!-- contributors:end -->\n',
+			);
+		} finally {
+			await file.cleanup();
+		}
+	});
+
+	test('updates multiple markers with multiline values', async () => {
+		const file = await createMarkdownFile(
+			'<!-- a:start --><!-- a:end -->\n<!-- b:start --><!-- b:end -->\n',
+		);
+
+		try {
+			await runCli(file.filePath, '--a=first', '--b=second\nline');
+
+			expect(await readFile(file.filePath, 'utf8')).toBe(
+				'<!-- a:start -->first<!-- a:end -->\n<!-- b:start -->\nsecond\nline\n<!-- b:end -->\n',
+			);
+		} finally {
+			await file.cleanup();
+		}
+	});
+
+	test('prints updated content to stdout without a marker flag', async () => {
+		const file = await createMarkdownFile('<!-- a:start -->value<!-- a:end -->');
+
+		try {
+			const { stdout } = await runCli(file.filePath);
+
+			expect(stdout).toBe('<!-- a:start -->value<!-- a:end -->');
+			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start -->value<!-- a:end -->');
+		} finally {
+			await file.cleanup();
+		}
+	});
+
+	test('exits non-zero when a valueless flag is passed', async () => {
+		const file = await createMarkdownFile('<!-- a:start --><!-- a:end -->');
+
+		try {
+			await expect(runCli(file.filePath, '--a')).rejects.toThrow(/No value provided for flag "--a"/);
+			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start --><!-- a:end -->');
+		} finally {
+			await file.cleanup();
+		}
+	});
+
+	test('leaves the file untouched when a marker is missing from the file', async () => {
+		const file = await createMarkdownFile('<!-- a:start --><!-- a:end -->');
+
+		try {
+			await runCli(file.filePath, '--missing=hi');
+
+			// commentMark ignores data keys with no matching marker, so the CLI
+			// succeeds while the file stays as-is.
+			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start --><!-- a:end -->');
+		} finally {
+			await file.cleanup();
+		}
+	});
+
+	test('exits non-zero when the file does not exist', async () => {
+		await expect(runCli('/nonexistent/path/README.md', '--a=hi')).rejects.toThrow(/ENOENT/);
 	});
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -275,13 +275,11 @@ describe('CLI', () => {
 		}
 	});
 
-	test('prints updated content to stdout without a marker flag', async () => {
+	test('exits with an error when no marker flags are passed', async () => {
 		const file = await createMarkdownFile('<!-- a:start -->value<!-- a:end -->');
 
 		try {
-			const { stdout } = await runCli(file.filePath);
-
-			expect(stdout).toBe('<!-- a:start -->value<!-- a:end -->');
+			await expect(runCli(file.filePath)).rejects.toThrow(/No marker flags provided/);
 			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start -->value<!-- a:end -->');
 		} finally {
 			await file.cleanup();

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -243,6 +243,47 @@ describe('CLI', () => {
 		expect(helpOutput).toContain(packageJson.description);
 	});
 
+	test('lists detected values as JSON when no marker flags are passed', async () => {
+		const file = await createMarkdownFile(
+			'<!-- a:start -->hello world<!-- a:end -->\n<!-- b:start -->\nmulti\nline\n<!-- b:end -->\n',
+		);
+
+		try {
+			const { stdout } = await runCli(file.filePath);
+
+			expect(JSON.parse(stdout)).toStrictEqual({
+				a: 'hello world',
+				b: '\nmulti\nline\n',
+			});
+		} finally {
+			await file.cleanup();
+		}
+	});
+
+	test('prints an empty JSON object in get mode when no markers exist', async () => {
+		const file = await createMarkdownFile('<!-- ordinary comment -->\n');
+
+		try {
+			const { stdout } = await runCli(file.filePath);
+
+			expect(JSON.parse(stdout)).toStrictEqual({});
+		} finally {
+			await file.cleanup();
+		}
+	});
+
+	test('allows setting a marker named like a control flag', async () => {
+		const file = await createMarkdownFile('<!-- version:start -->1.0.0<!-- version:end -->');
+
+		try {
+			await runCli(file.filePath, '--version=2.0.0');
+
+			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- version:start -->2.0.0<!-- version:end -->');
+		} finally {
+			await file.cleanup();
+		}
+	});
+
 	test('updates a marked section in place', async () => {
 		const file = await createMarkdownFile(
 			'## Contributors\n<!-- contributors:start -->stale<!-- contributors:end -->\n',
@@ -275,12 +316,60 @@ describe('CLI', () => {
 		}
 	});
 
-	test('exits with an error when no marker flags are passed', async () => {
+	test('reports per-key outcomes and exits non-zero when markers are missing', async () => {
+		const file = await createMarkdownFile(
+			'<!-- a:start -->stale<!-- a:end -->\n<!-- b:start -->same<!-- b:end -->\n',
+		);
+
+		try {
+			const invocation = runCli(file.filePath, '--a=fresh', '--b=same', '--nope=x');
+
+			await expect(invocation).rejects.toMatchObject({ code: 1 });
+			await expect(invocation).rejects.toThrow(/Updated: a[\s\S]*Unchanged: b[\s\S]*Missing: nope/);
+			await expect(invocation).rejects.toThrow(/Saved .*\. Updated 1 key; 1 unchanged; 1 missing\./);
+
+			// Valid updates are still saved when other keys are missing.
+			expect(await readFile(file.filePath, 'utf8')).toBe(
+				'<!-- a:start -->fresh<!-- a:end -->\n<!-- b:start -->same<!-- b:end -->\n',
+			);
+		} finally {
+			await file.cleanup();
+		}
+	});
+
+	test('exits successfully when all requested values already match', async () => {
+		const file = await createMarkdownFile('<!-- a:start -->same<!-- a:end -->');
+
+		try {
+			const { stderr } = await runCli(file.filePath, '--a=same');
+
+			expect(stderr).toContain('is unchanged. All 1 requested values already match.');
+			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start -->same<!-- a:end -->');
+		} finally {
+			await file.cleanup();
+		}
+	});
+
+	test('exits non-zero without writing when every requested marker is missing', async () => {
 		const file = await createMarkdownFile('<!-- a:start -->value<!-- a:end -->');
 
 		try {
-			await expect(runCli(file.filePath)).rejects.toThrow(/No marker flags provided/);
+			await expect(runCli(file.filePath, '--nope1=x', '--nope2=y')).rejects.toThrow(
+				/No matching markers found for any of the 2 requested keys/,
+			);
 			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start -->value<!-- a:end -->');
+		} finally {
+			await file.cleanup();
+		}
+	});
+
+	test('clears a section when the value is empty', async () => {
+		const file = await createMarkdownFile('<!-- a:start -->gone<!-- a:end -->');
+
+		try {
+			await runCli(file.filePath, '--a=');
+
+			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start --><!-- a:end -->');
 		} finally {
 			await file.cleanup();
 		}
@@ -297,15 +386,36 @@ describe('CLI', () => {
 		}
 	});
 
-	test('leaves the file untouched when a marker is missing from the file', async () => {
+	test('exits non-zero when the same flag is passed multiple times', async () => {
 		const file = await createMarkdownFile('<!-- a:start --><!-- a:end -->');
 
 		try {
-			await runCli(file.filePath, '--missing=hi');
-
-			// commentMark ignores data keys with no matching marker, so the CLI
-			// succeeds while the file stays as-is.
+			await expect(runCli(file.filePath, '--a=1', '--a=2')).rejects.toThrow(
+				/Flag "--a" was specified 2 times/,
+			);
 			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start --><!-- a:end -->');
+		} finally {
+			await file.cleanup();
+		}
+	});
+
+	test('exits non-zero on unexpected extra positional arguments', async () => {
+		const file = await createMarkdownFile('<!-- a:start --><!-- a:end -->');
+
+		try {
+			await expect(runCli(file.filePath, 'extra', '--a=1')).rejects.toThrow(/Unexpected extra arguments: extra/);
+			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start --><!-- a:end -->');
+		} finally {
+			await file.cleanup();
+		}
+	});
+
+	test('exits non-zero and leaves the file untouched when a marker is unterminated', async () => {
+		const file = await createMarkdownFile('<!-- a:start -->never closed\n');
+
+		try {
+			await expect(runCli(file.filePath, '--a=x')).rejects.toThrow(/No end comment found for key "a"/);
+			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start -->never closed\n');
 		} finally {
 			await file.cleanup();
 		}

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -226,6 +226,23 @@ goodbye world
 });
 
 describe('CLI', () => {
+	test('sources name, description, and version from package.json', async () => {
+		const packageJson = JSON.parse(
+			await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+		) as {
+			name: string;
+			description: string;
+			version: string;
+		};
+
+		const { stdout: versionOutput } = await runCli('--version');
+		expect(versionOutput.trim()).toBe(packageJson.version);
+
+		const { stdout: helpOutput } = await runCli('--help');
+		expect(helpOutput).toContain(packageJson.name);
+		expect(helpOutput).toContain(packageJson.description);
+	});
+
 	test('updates a marked section in place', async () => {
 		const file = await createMarkdownFile(
 			'## Contributors\n<!-- contributors:start -->stale<!-- contributors:end -->\n',

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,34 +1,8 @@
-import {
-	mkdtemp, rm, writeFile, readFile,
-} from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import path from 'node:path';
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
+import { readFile } from 'node:fs/promises';
+import { createFixture } from 'fs-fixture';
 import { describe, test, expect } from 'manten';
 import { commentMark, getCommentMarks } from '#comment-mark';
-
-const execFileAsync = promisify(execFile);
-const cliPath = new URL('../dist/cli.mjs', import.meta.url).pathname;
-
-const runCli = (...args: string[]) => execFileAsync('node', [cliPath, ...args], {
-	encoding: 'utf8',
-});
-
-const createMarkdownFile = async (content: string) => {
-	const directory = await mkdtemp(path.join(tmpdir(), 'comment-mark-cli-'));
-	const filePath = path.join(directory, 'README.md');
-	await writeFile(filePath, content, 'utf8');
-	return {
-		filePath,
-		cleanup: async () => {
-			await rm(directory, {
-				recursive: true,
-				force: true,
-			});
-		},
-	};
-};
+import { commentMarkCli } from './utils/comment-mark-cli.js';
 
 describe('edge cases', () => {
 	test('no arguments', () => {
@@ -235,193 +209,161 @@ describe('CLI', () => {
 			version: string;
 		};
 
-		const { stdout: versionOutput } = await runCli('--version');
-		expect(versionOutput.trim()).toBe(packageJson.version);
+		const { stdout: versionOutput } = await commentMarkCli('--version');
+		expect(versionOutput).toBe(packageJson.version);
 
-		const { stdout: helpOutput } = await runCli('--help');
+		const { stdout: helpOutput } = await commentMarkCli('--help');
 		expect(helpOutput).toContain(packageJson.name);
 		expect(helpOutput).toContain(packageJson.description);
 	});
 
 	test('lists detected values as JSON when no marker flags are passed', async () => {
-		const file = await createMarkdownFile(
-			'<!-- a:start -->hello world<!-- a:end -->\n<!-- b:start -->\nmulti\nline\n<!-- b:end -->\n',
-		);
+		await using fixture = await createFixture({
+			'README.md': '<!-- a:start -->hello world<!-- a:end -->\n<!-- b:start -->\nmulti\nline\n<!-- b:end -->\n',
+		});
 
-		try {
-			const { stdout } = await runCli(file.filePath);
+		const { stdout } = await commentMarkCli(fixture.getPath('README.md'));
 
-			expect(JSON.parse(stdout)).toStrictEqual({
-				a: 'hello world',
-				b: '\nmulti\nline\n',
-			});
-		} finally {
-			await file.cleanup();
-		}
+		expect(JSON.parse(stdout)).toStrictEqual({
+			a: 'hello world',
+			b: '\nmulti\nline\n',
+		});
 	});
 
 	test('prints an empty JSON object in get mode when no markers exist', async () => {
-		const file = await createMarkdownFile('<!-- ordinary comment -->\n');
+		await using fixture = await createFixture({ 'README.md': '<!-- ordinary comment -->\n' });
 
-		try {
-			const { stdout } = await runCli(file.filePath);
+		const { stdout } = await commentMarkCli(fixture.getPath('README.md'));
 
-			expect(JSON.parse(stdout)).toStrictEqual({});
-		} finally {
-			await file.cleanup();
-		}
+		expect(JSON.parse(stdout)).toStrictEqual({});
 	});
 
 	test('allows setting a marker named like a control flag', async () => {
-		const file = await createMarkdownFile('<!-- version:start -->1.0.0<!-- version:end -->');
+		await using fixture = await createFixture({
+			'README.md': '<!-- version:start -->1.0.0<!-- version:end -->',
+		});
 
-		try {
-			await runCli(file.filePath, '--version=2.0.0');
+		await commentMarkCli(fixture.getPath('README.md'), '--version=2.0.0');
 
-			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- version:start -->2.0.0<!-- version:end -->');
-		} finally {
-			await file.cleanup();
-		}
+		expect(await fixture.readFile('README.md', 'utf8')).toBe('<!-- version:start -->2.0.0<!-- version:end -->');
 	});
 
 	test('updates a marked section in place', async () => {
-		const file = await createMarkdownFile(
-			'## Contributors\n<!-- contributors:start -->stale<!-- contributors:end -->\n',
+		await using fixture = await createFixture({
+			'README.md': '## Contributors\n<!-- contributors:start -->stale<!-- contributors:end -->\n',
+		});
+
+		await commentMarkCli(fixture.getPath('README.md'), '--contributors=Jane Doe');
+
+		expect(await fixture.readFile('README.md', 'utf8')).toBe(
+			'## Contributors\n<!-- contributors:start -->Jane Doe<!-- contributors:end -->\n',
 		);
-
-		try {
-			await runCli(file.filePath, '--contributors=Jane Doe');
-
-			expect(await readFile(file.filePath, 'utf8')).toBe(
-				'## Contributors\n<!-- contributors:start -->Jane Doe<!-- contributors:end -->\n',
-			);
-		} finally {
-			await file.cleanup();
-		}
 	});
 
 	test('updates multiple markers with multiline values', async () => {
-		const file = await createMarkdownFile(
-			'<!-- a:start --><!-- a:end -->\n<!-- b:start --><!-- b:end -->\n',
+		await using fixture = await createFixture({
+			'README.md': '<!-- a:start --><!-- a:end -->\n<!-- b:start --><!-- b:end -->\n',
+		});
+
+		await commentMarkCli(fixture.getPath('README.md'), '--a=first', '--b=second\nline');
+
+		expect(await fixture.readFile('README.md', 'utf8')).toBe(
+			'<!-- a:start -->first<!-- a:end -->\n<!-- b:start -->\nsecond\nline\n<!-- b:end -->\n',
 		);
-
-		try {
-			await runCli(file.filePath, '--a=first', '--b=second\nline');
-
-			expect(await readFile(file.filePath, 'utf8')).toBe(
-				'<!-- a:start -->first<!-- a:end -->\n<!-- b:start -->\nsecond\nline\n<!-- b:end -->\n',
-			);
-		} finally {
-			await file.cleanup();
-		}
 	});
 
 	test('reports per-key outcomes and exits non-zero when markers are missing', async () => {
-		const file = await createMarkdownFile(
-			'<!-- a:start -->stale<!-- a:end -->\n<!-- b:start -->same<!-- b:end -->\n',
+		await using fixture = await createFixture({
+			'README.md': '<!-- a:start -->stale<!-- a:end -->\n<!-- b:start -->same<!-- b:end -->\n',
+		});
+
+		const invocation = commentMarkCli(fixture.getPath('README.md'), '--a=fresh', '--b=same', '--nope=x');
+
+		await expect(invocation).rejects.toMatchObject({
+			exitCode: 1,
+			stderr: expect.stringMatching(/Updated: a[\s\S]*Unchanged: b[\s\S]*Missing: nope/),
+		});
+		await expect(invocation).rejects.toMatchObject({
+			stderr: expect.stringMatching(/Saved .*\. Updated 1 key; 1 unchanged; 1 missing\./),
+		});
+
+		// Valid updates are still saved when other keys are missing.
+		expect(await fixture.readFile('README.md', 'utf8')).toBe(
+			'<!-- a:start -->fresh<!-- a:end -->\n<!-- b:start -->same<!-- b:end -->\n',
 		);
-
-		try {
-			const invocation = runCli(file.filePath, '--a=fresh', '--b=same', '--nope=x');
-
-			await expect(invocation).rejects.toMatchObject({ code: 1 });
-			await expect(invocation).rejects.toThrow(/Updated: a[\s\S]*Unchanged: b[\s\S]*Missing: nope/);
-			await expect(invocation).rejects.toThrow(/Saved .*\. Updated 1 key; 1 unchanged; 1 missing\./);
-
-			// Valid updates are still saved when other keys are missing.
-			expect(await readFile(file.filePath, 'utf8')).toBe(
-				'<!-- a:start -->fresh<!-- a:end -->\n<!-- b:start -->same<!-- b:end -->\n',
-			);
-		} finally {
-			await file.cleanup();
-		}
 	});
 
 	test('exits successfully when all requested values already match', async () => {
-		const file = await createMarkdownFile('<!-- a:start -->same<!-- a:end -->');
+		await using fixture = await createFixture({ 'README.md': '<!-- a:start -->same<!-- a:end -->' });
 
-		try {
-			const { stderr } = await runCli(file.filePath, '--a=same');
+		const { stderr } = await commentMarkCli(fixture.getPath('README.md'), '--a=same');
 
-			expect(stderr).toContain('is unchanged. All 1 requested values already match.');
-			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start -->same<!-- a:end -->');
-		} finally {
-			await file.cleanup();
-		}
+		expect(stderr).toContain('is unchanged. All 1 requested values already match.');
+		expect(await fixture.readFile('README.md', 'utf8')).toBe('<!-- a:start -->same<!-- a:end -->');
 	});
 
 	test('exits non-zero without writing when every requested marker is missing', async () => {
-		const file = await createMarkdownFile('<!-- a:start -->value<!-- a:end -->');
+		await using fixture = await createFixture({ 'README.md': '<!-- a:start -->value<!-- a:end -->' });
 
-		try {
-			await expect(runCli(file.filePath, '--nope1=x', '--nope2=y')).rejects.toThrow(
-				/No matching markers found for any of the 2 requested keys/,
-			);
-			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start -->value<!-- a:end -->');
-		} finally {
-			await file.cleanup();
-		}
+		await expect(commentMarkCli(fixture.getPath('README.md'), '--nope1=x', '--nope2=y')).rejects.toMatchObject({
+			exitCode: 1,
+			stderr: expect.stringContaining('No matching markers found for any of the 2 requested keys'),
+		});
+		expect(await fixture.readFile('README.md', 'utf8')).toBe('<!-- a:start -->value<!-- a:end -->');
 	});
 
 	test('clears a section when the value is empty', async () => {
-		const file = await createMarkdownFile('<!-- a:start -->gone<!-- a:end -->');
+		await using fixture = await createFixture({ 'README.md': '<!-- a:start -->gone<!-- a:end -->' });
 
-		try {
-			await runCli(file.filePath, '--a=');
+		await commentMarkCli(fixture.getPath('README.md'), '--a=');
 
-			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start --><!-- a:end -->');
-		} finally {
-			await file.cleanup();
-		}
+		expect(await fixture.readFile('README.md', 'utf8')).toBe('<!-- a:start --><!-- a:end -->');
 	});
 
 	test('exits non-zero when a valueless flag is passed', async () => {
-		const file = await createMarkdownFile('<!-- a:start --><!-- a:end -->');
+		await using fixture = await createFixture({ 'README.md': '<!-- a:start --><!-- a:end -->' });
 
-		try {
-			await expect(runCli(file.filePath, '--a')).rejects.toThrow(/No value provided for flag "--a"/);
-			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start --><!-- a:end -->');
-		} finally {
-			await file.cleanup();
-		}
+		await expect(commentMarkCli(fixture.getPath('README.md'), '--a')).rejects.toMatchObject({
+			exitCode: 1,
+			stderr: expect.stringContaining('No value provided for flag "--a"'),
+		});
+		expect(await fixture.readFile('README.md', 'utf8')).toBe('<!-- a:start --><!-- a:end -->');
 	});
 
 	test('exits non-zero when the same flag is passed multiple times', async () => {
-		const file = await createMarkdownFile('<!-- a:start --><!-- a:end -->');
+		await using fixture = await createFixture({ 'README.md': '<!-- a:start --><!-- a:end -->' });
 
-		try {
-			await expect(runCli(file.filePath, '--a=1', '--a=2')).rejects.toThrow(
-				/Flag "--a" was specified 2 times/,
-			);
-			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start --><!-- a:end -->');
-		} finally {
-			await file.cleanup();
-		}
+		await expect(commentMarkCli(fixture.getPath('README.md'), '--a=1', '--a=2')).rejects.toMatchObject({
+			exitCode: 1,
+			stderr: expect.stringContaining('Flag "--a" was specified 2 times'),
+		});
+		expect(await fixture.readFile('README.md', 'utf8')).toBe('<!-- a:start --><!-- a:end -->');
 	});
 
 	test('exits non-zero on unexpected extra positional arguments', async () => {
-		const file = await createMarkdownFile('<!-- a:start --><!-- a:end -->');
+		await using fixture = await createFixture({ 'README.md': '<!-- a:start --><!-- a:end -->' });
 
-		try {
-			await expect(runCli(file.filePath, 'extra', '--a=1')).rejects.toThrow(/Unexpected extra arguments: extra/);
-			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start --><!-- a:end -->');
-		} finally {
-			await file.cleanup();
-		}
+		await expect(commentMarkCli(fixture.getPath('README.md'), 'extra', '--a=1')).rejects.toMatchObject({
+			exitCode: 1,
+			stderr: expect.stringContaining('Unexpected extra arguments: extra'),
+		});
+		expect(await fixture.readFile('README.md', 'utf8')).toBe('<!-- a:start --><!-- a:end -->');
 	});
 
 	test('exits non-zero and leaves the file untouched when a marker is unterminated', async () => {
-		const file = await createMarkdownFile('<!-- a:start -->never closed\n');
+		await using fixture = await createFixture({ 'README.md': '<!-- a:start -->never closed\n' });
 
-		try {
-			await expect(runCli(file.filePath, '--a=x')).rejects.toThrow(/No end comment found for key "a"/);
-			expect(await readFile(file.filePath, 'utf8')).toBe('<!-- a:start -->never closed\n');
-		} finally {
-			await file.cleanup();
-		}
+		await expect(commentMarkCli(fixture.getPath('README.md'), '--a=x')).rejects.toMatchObject({
+			exitCode: 1,
+			stderr: expect.stringContaining('No end comment found for key "a"'),
+		});
+		expect(await fixture.readFile('README.md', 'utf8')).toBe('<!-- a:start -->never closed\n');
 	});
 
 	test('exits non-zero when the file does not exist', async () => {
-		await expect(runCli('/nonexistent/path/README.md', '--a=hi')).rejects.toThrow(/ENOENT/);
+		await expect(commentMarkCli('/nonexistent/path/README.md', '--a=hi')).rejects.toMatchObject({
+			exitCode: 1,
+			stderr: expect.stringContaining('ENOENT'),
+		});
 	});
 });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -215,6 +215,9 @@ describe('CLI', () => {
 		const { stdout: helpOutput } = await commentMarkCli('--help');
 		expect(helpOutput).toContain(packageJson.name);
 		expect(helpOutput).toContain(packageJson.description);
+
+		const { stdout: shortHelpOutput } = await commentMarkCli('-h');
+		expect(shortHelpOutput).toBe(helpOutput);
 	});
 
 	test('lists detected values as JSON when no marker flags are passed', async () => {
@@ -238,14 +241,16 @@ describe('CLI', () => {
 		expect(JSON.parse(stdout)).toStrictEqual({});
 	});
 
-	test('allows setting a marker named like a control flag', async () => {
+	test('allows setting markers named like control flags', async () => {
 		await using fixture = await createFixture({
-			'README.md': '<!-- version:start -->1.0.0<!-- version:end -->',
+			'README.md': '<!-- help:start -->stale<!-- help:end -->\n<!-- version:start -->1.0.0<!-- version:end -->\n',
 		});
 
-		await commentMarkCli(fixture.getPath('README.md'), '--version=2.0.0');
+		await commentMarkCli(fixture.getPath('README.md'), '--help=docs', '--version=2.0.0');
 
-		expect(await fixture.readFile('README.md', 'utf8')).toBe('<!-- version:start -->2.0.0<!-- version:end -->');
+		expect(await fixture.readFile('README.md', 'utf8')).toBe(
+			'<!-- help:start -->docs<!-- help:end -->\n<!-- version:start -->2.0.0<!-- version:end -->\n',
+		);
 	});
 
 	test('updates a marked section in place', async () => {

--- a/tests/utils/comment-mark-cli.ts
+++ b/tests/utils/comment-mark-cli.ts
@@ -1,0 +1,9 @@
+import { fileURLToPath } from 'node:url';
+import spawn from 'nano-spawn';
+
+const cliPath = fileURLToPath(new URL('../../dist/cli.mjs', import.meta.url));
+
+export const commentMarkCli = (...args: string[]) => spawn(process.execPath, [
+	cliPath,
+	...args,
+]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 	"compilerOptions": {
 		"target": "ES2023", // Node 20
 		"module": "Preserve",
+		"resolveJsonModule": true,
 		"types": [
 			"node",
 		],


### PR DESCRIPTION
## Problem

**comment-mark** is a library only: to inspect or update a Markdown file's marked sections, you have to write a small Node script that reads the file, calls the API, and writes it back. For recurring updates (refreshing a contributors list, stamping a date), that script is boilerplate, and there's no easy way to see what values a file currently holds.

## Changes

This adds a `comment-mark` CLI (same name as the package) with two modes:

**Get mode** — running without marker flags lists every detected marker and its exact content as JSON on stdout, ready for scripting:

```sh
comment-mark README.md | jq -r '.contributors'
```

**Set mode** — each `--<marker>=<value>` flag fills the matching marker in place, and the command reports each key's outcome on stderr:

```sh
$ comment-mark README.md --contributors="Jane Doe" --lastUpdated="2026-09-07" --benchmarks="result"
Updated: contributors
Unchanged: lastUpdated
Missing: benchmarks

Saved README.md. Updated 1 key; 1 unchanged; 1 missing.
```

A marker that doesn't exist doesn't block the other updates, but the command exits `1` so typos and stale scripts surface. When every requested value already matches, the file is left untouched and the command exits `0`.

Implementation notes for reviewers:

- Built on `cleye` v2 (not the 3.0 beta) because the beta requires Node >=22.22.2 and this package supports Node >=20.
- Values must use `--<marker>=<value>` syntax: with space-delimited values, type-flag v4 treats an unknown flag as boolean and drops its value into positionals. With `help: false`, bare `--help`/`-h`/`--version` are handled manually, so markers named `help` or `version` remain settable via `--version=2.0.0`.
- Repeated flags, extra positional arguments, and unterminated markers are rejected before writing, so a malformed invocation never leaves partial edits behind.
- `pkgroll` builds the CLI from the `bin` field into `dist/cli.mjs` (hashbang + executable bit included), and the tarball ships it.
- New CLI integration tests run the built binary against real temp files, covering both modes, per-key outcomes, exit codes, and every rejection path.